### PR TITLE
Resolved #751

### DIFF
--- a/spec/amber/cli/commands/pipelines/pipelines_spec.cr
+++ b/spec/amber/cli/commands/pipelines/pipelines_spec.cr
@@ -52,7 +52,7 @@ module Amber::CLI
           output_lines = route_table_rows(output)
 
           it "outputs the correct headers" do
-            headers = %w(Pipe Plug)
+            headers = %w(Pipeline Pipe)
             headers.each do |header|
               output.should contain header
             end

--- a/spec/support/fixtures/render_fixtures.cr
+++ b/spec/support/fixtures/render_fixtures.cr
@@ -13,8 +13,8 @@ module RenderFixtures
       <div class="form-group">
         <textarea class="form-control" rows="10" name="content" placeholder="Content">out there in the cold</textarea>
       </div>
-      <button class="btn btn-primary btn-xs" type="submit">Submit</button>
-      <a class="btn btn-default btn-xs" href="/posts">back</a>
+      <button class="btn btn-primary btn-sm" type="submit">Submit</button>
+      <a class="btn btn-default btn-sm" href="/posts">back</a>
     </form>
     HTML
   end

--- a/spec/support/fixtures/render_fixtures.cr
+++ b/spec/support/fixtures/render_fixtures.cr
@@ -14,7 +14,7 @@ module RenderFixtures
         <textarea class="form-control" rows="10" name="content" placeholder="Content">out there in the cold</textarea>
       </div>
       <button class="btn btn-primary btn-sm" type="submit">Submit</button>
-      <a class="btn btn-default btn-sm" href="/posts">back</a>
+      <a class="btn btn-light btn-sm" href="/posts">back</a>
     </form>
     HTML
   end

--- a/spec/support/sample/views/test/_form.slang
+++ b/spec/support/sample/views/test/_form.slang
@@ -1,8 +1,8 @@
 form action="/posts" method="post"
   == csrf_tag
-  div.form-group
+  .form-group
     input.form-control type="text" name="title" placeholder="Title" value="hey you"
-  div.form-group
+  .form-group
     textarea.form-control rows="10" name="content" placeholder="Content" = "out there in the cold"
   button.btn.btn-primary.btn-sm type="submit" Submit
   a.btn.btn-light.btn-sm href="/posts" back

--- a/spec/support/sample/views/test/_form.slang
+++ b/spec/support/sample/views/test/_form.slang
@@ -5,4 +5,4 @@ form action="/posts" method="post"
   div.form-group
     textarea.form-control rows="10" name="content" placeholder="Content" = "out there in the cold"
   button.btn.btn-primary.btn-sm type="submit" Submit
-  a.btn.btn-default.btn-sm href="/posts" back
+  a.btn.btn-light.btn-sm href="/posts" back

--- a/spec/support/sample/views/test/_form.slang
+++ b/spec/support/sample/views/test/_form.slang
@@ -3,6 +3,6 @@ form action="/posts" method="post"
   div.form-group
     input.form-control type="text" name="title" placeholder="Title" value="hey you"
   div.form-group
-    textarea.form-control rows="10" name="content" placeholder="Content" = "out there in the cold" 
-  button.btn.btn-primary.btn-xs type="submit" Submit
-  a.btn.btn-default.btn-xs href="/posts" back
+    textarea.form-control rows="10" name="content" placeholder="Content" = "out there in the cold"
+  button.btn.btn-primary.btn-sm type="submit" Submit
+  a.btn.btn-default.btn-sm href="/posts" back

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -54,7 +54,7 @@ module Amber::CLI
           when "create"
             Micrate.logger.info create_database
           when "seed"
-            `crystal db/seeds.cr`
+            Helpers.run("crystal db/seeds.cr", wait: true, shell: true)
             Micrate.logger.info "Seeded database"
           when "migrate"
             begin

--- a/src/amber/cli/commands/pipelines.cr
+++ b/src/amber/cli/commands/pipelines.cr
@@ -18,8 +18,8 @@ module Amber::CLI
       end
 
       ROUTES_PATH          = "config/routes.cr"
-      LABELS               = %w(Pipe Plug)
-      LABELS_WITHOUT_PLUGS = %w(Pipe)
+      LABELS               = %w(Pipeline Pipe)
+      LABELS_WITHOUT_PLUGS = %w(Pipeline)
 
       PIPELINE_REGEX =
         /^

--- a/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
+++ b/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
@@ -36,8 +36,6 @@ h6, .h6 {
  */
 .masthead {
   background-color: $background-color;
-  -webkit-box-shadow: inset 0 -2px 5px rgba(0,0,0,.1);
-          box-shadow: inset 0 -2px 5px rgba(0,0,0,.1);
 }
 
 /* Nav links */

--- a/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
+++ b/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
@@ -54,24 +54,6 @@ h6, .h6 {
   text-decoration: none;
 }
 
-/* Active state gets a caret at the bottom */
-.nav .active {
-  color: #fff;
-}
-.nav .active:after {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  width: 0;
-  height: 0;
-  margin-left: -5px;
-  vertical-align: middle;
-  content: " ";
-  border-right: 5px solid transparent;
-  border-bottom: 5px solid;
-  border-left: 5px solid transparent;
-}
-
 .main {
   padding-top: 20px;
 }
@@ -80,12 +62,16 @@ h6, .h6 {
   background-color: $background-color;
   background-image: url("../images/logo.png");
   background-size:contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-radius:5px;
+  margin: auto;
   width: 200px;
   height:278px;
 }
 
 /* Hide logo in small screens */
-@media (max-width: 767px) {
+@media (max-width: 575px) {
   #logo {
     display: none;
   }

--- a/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
+++ b/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
@@ -103,3 +103,15 @@ h6, .h6 {
     margin-bottom: 0;
   }
 }
+
+// For Navigation pulling right
+.nav-item-auth {
+  &.nav-item-auth-signout, &.nav-item-auth-signup {
+    order: 9999;
+  }
+
+  &.nav-item-auth-profile, &.nav-item-auth-signin {
+    order: 9990;
+    margin-left: auto;
+  }
+}

--- a/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
+++ b/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
@@ -94,3 +94,12 @@ h6, .h6 {
 .table td, .table th {
   vertical-align: middle;
 }
+
+.alert {
+  margin-top: 1em;
+
+  p {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
+++ b/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
@@ -90,3 +90,7 @@ h6, .h6 {
     display: none;
   }
 }
+
+.table td, .table th {
+  vertical-align: middle;
+}

--- a/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
@@ -1,7 +1,9 @@
 <div class="row">
-  <div id="logo"></div>
-  <div class="col-sm-6">
-    <h2><%= "<" %>%= t "welcome_to_amber" %></h2>
+  <div class="col-sm">
+    <div id="logo"></div>
+  </div>
+  <div class="col-sm">
+    <h2><%= t "welcome_to_amber" %></h2>
     <p>Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.</p>
     <div class="list-group">
       <a class="list-group-item list-group-item-action" target="_blank" href="https://docs.amberframework.org">Getting Started with Amber Framework</a>

--- a/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
@@ -3,7 +3,7 @@
     <div id="logo"></div>
   </div>
   <div class="col-sm">
-    <h2><%= t "welcome_to_amber" %></h2>
+    <h2><%= "<" %>%= t "welcome_to_amber" %></h2>
     <p>Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.</p>
     <div class="list-group">
       <a class="list-group-item list-group-item-action" target="_blank" href="https://docs.amberframework.org">Getting Started with Amber Framework</a>

--- a/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
@@ -1,10 +1,12 @@
-<div id="logo" class="col-sm-6"></div>
-<div class="col-sm-6">
-  <h2><%= "<" %>%= t "welcome_to_amber" %></h2>
-  <p>Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.</p>
-  <div class="list-group">
-    <a class="list-group-item list-group-item-action" target="_blank" href="https://docs.amberframework.org">Getting Started with Amber Framework</a>
-    <a class="list-group-item list-group-item-action" target="_blank" href="https://github.com/veelenga/awesome-crystal">List of Awesome Crystal projects and shards</a>
-    <a class="list-group-item list-group-item-action" target="_blank" href="https://crystalshards.xyz">What's hot in Crystal right now</a>
+<div class="row">
+  <div id="logo" class="col-sm-6"></div>
+  <div class="col-sm-6">
+    <h2><%= "<" %>%= t "welcome_to_amber" %></h2>
+    <p>Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.</p>
+    <div class="list-group">
+      <a class="list-group-item list-group-item-action" target="_blank" href="https://docs.amberframework.org">Getting Started with Amber Framework</a>
+      <a class="list-group-item list-group-item-action" target="_blank" href="https://github.com/veelenga/awesome-crystal">List of Awesome Crystal projects and shards</a>
+      <a class="list-group-item list-group-item-action" target="_blank" href="https://crystalshards.xyz">What's hot in Crystal right now</a>
+    </div>
   </div>
 </div>

--- a/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
@@ -1,5 +1,5 @@
 <div class="row">
-  <div id="logo" class="col-sm-6"></div>
+  <div id="logo"></div>
   <div class="col-sm-6">
     <h2><%= "<" %>%= t "welcome_to_amber" %></h2>
     <p>Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.</p>

--- a/src/amber/cli/templates/app/src/views/home/index.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.slang.ecr
@@ -1,6 +1,7 @@
 .row
-  #logo
-  .col-sm-6
+  .col-sm
+    #logo
+  .col-sm
     h2 = t "welcome_to_amber"
     p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.
     .list-group

--- a/src/amber/cli/templates/app/src/views/home/index.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.slang.ecr
@@ -1,9 +1,9 @@
 .row
   #logo
-  div.col-sm-6
+  .col-sm-6
     h2 = t "welcome_to_amber"
     p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.
-    div.list-group
+    .list-group
       a.list-group-item.list-group-item-action target="_blank" href="https://docs.amberframework.org" Getting Started with Amber Framework
       a.list-group-item.list-group-item-action target="_blank" href="https://github.com/veelenga/awesome-crystal" List of Awesome Crystal projects and shards
       a.list-group-item.list-group-item-action target="_blank" href="https://crystalshards.xyz" What's hot in Crystal right now

--- a/src/amber/cli/templates/app/src/views/home/index.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.slang.ecr
@@ -1,5 +1,5 @@
 div.row
-  div#logo.col-sm-6
+  div#logo
   div.col-sm-6
     h2 = t "welcome_to_amber"
     p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.

--- a/src/amber/cli/templates/app/src/views/home/index.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.slang.ecr
@@ -1,8 +1,9 @@
-div#logo.col-sm-6
-div.col-sm-6
-  h2 = t "welcome_to_amber"
-  p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.
-  div.list-group
-    a.list-group-item.list-group-item-action target="_blank" href="https://docs.amberframework.org" Getting Started with Amber Framework
-    a.list-group-item.list-group-item-action target="_blank" href="https://github.com/veelenga/awesome-crystal" List of Awesome Crystal projects and shards
-    a.list-group-item.list-group-item-action target="_blank" href="https://crystalshards.xyz" What's hot in Crystal right now
+div.row
+  div#logo.col-sm-6
+  div.col-sm-6
+    h2 = t "welcome_to_amber"
+    p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.
+    div.list-group
+      a.list-group-item.list-group-item-action target="_blank" href="https://docs.amberframework.org" Getting Started with Amber Framework
+      a.list-group-item.list-group-item-action target="_blank" href="https://github.com/veelenga/awesome-crystal" List of Awesome Crystal projects and shards
+      a.list-group-item.list-group-item-action target="_blank" href="https://crystalshards.xyz" What's hot in Crystal right now

--- a/src/amber/cli/templates/app/src/views/home/index.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.slang.ecr
@@ -1,5 +1,5 @@
-div.row
-  div#logo
+.row
+  #logo
   div.col-sm-6
     h2 = t "welcome_to_amber"
     p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -11,8 +11,17 @@
   <body>
     <div class="masthead">
       <div class="container">
-        <nav class="nav">
-          <%="<"%>%= render(partial: "layouts/_nav.ecr") %>
+        
+        <nav class="navbar navbar-expand-lg">
+          <a class="navbar-brand" href="#"><%= display_name %></a>
+          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+            <div class="navbar-nav">
+              <%="<"%>%= render(partial: "layouts/_nav.ecr") %>
+            </div>
+          </div>
         </nav>
       </div>
     </div>
@@ -27,12 +36,11 @@
           <%="<"%>%- end %>
         </div>
       </div>
-
-      <div class="row">
-        <div class="col-sm-12 main">
-          <%="<"%>%= content %>
-        </div>
+    
+      <div class="main">
+        <%="<"%>%= content %>
       </div>
+    </div>
 
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -11,8 +11,7 @@
   <body>
     <div class="masthead">
       <div class="container">
-        
-        <nav class="navbar navbar-expand-lg">
+        <nav class="navbar navbar-expand-lg navbar-dark">
           <a class="navbar-brand" href="#"><%= display_name %></a>
           <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
@@ -37,8 +36,10 @@
         </div>
       </div>
     
-      <div class="main">
-        <%="<"%>%= content %>
+      <div class="row">
+        <div class="main">
+          <%="<"%>%= content %>
+        </div>      
       </div>
     </div>
 

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -19,11 +19,13 @@
 
     <div class="container">
       <div class="row">
-        <%="<"%>%- flash.each do |key, value| %>
-          <div class="alert alert-<%="<"%>%= key %>">
-            <p><%="<"%>%= flash[key] %></p>
-          </div>
-        <%="<"%>%- end %>
+	<div class="col-sm">
+          <%="<"%>%- flash.each do |key, value| %>
+            <div class="alert alert-<%="<"%>%= key %>">
+              <p><%="<"%>%= flash[key] %></p>
+            </div>
+          <%="<"%>%- end %>
+        </div>
       </div>
 
       <div class="row">

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="/dist/main.bundle.css">
   <head>
   <body>
@@ -32,8 +32,9 @@
         </div>
       </div>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
     <script src="/dist/main.bundle.js"></script>
   </body>
 </html>

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -34,7 +34,7 @@
         </div>
       </div>
 
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
     <script src="/dist/main.bundle.js"></script>

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -19,7 +19,7 @@
 
     <div class="container">
       <div class="row">
-	<div class="col-sm">
+        <div class="col-sm">
           <%="<"%>%- flash.each do |key, value| %>
             <div class="alert alert-<%="<"%>%= key %>">
               <p><%="<"%>%= flash[key] %></p>

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -11,16 +11,22 @@ html
   body
     .masthead
       .container
-        nav.nav
-          == render(partial: "layouts/_nav.slang")
+        nav.navbar.navbar-expand-lg.navbar-dark
+          a.navbar-brand href="#" <%= display_name %>
+          button.navbar-toggler type="icon" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation"
+            span.navbar-toggler-icon
+          div.collapse.navbar-collapse#navbarNavAltMarkup
+            div.navbar-nav
+              == render(partial: "layouts/_nav.slang")
     .container
       .row
         .col-sm
           - flash.each do |key, value|
             div class="alert alert-#{key}"
               p = flash[key]
-      .main
-        == content
+      .row
+        .main
+          == content
 
     script src="https://code.jquery.com/jquery-3.3.1.min.js"
     script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -19,9 +19,8 @@ html
           - flash.each do |key, value|
             div class="alert alert-#{key}"
               p = flash[key]
-      .row
-        .col-sm-12.main
-          == content
+      .main
+        == content
 
     script src="https://code.jquery.com/jquery-3.3.1.min.js"
     script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -23,7 +23,7 @@ html
         div.col-sm-12.main
           == content
 
-    script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    script src="https://code.jquery.com/jquery-3.3.1.min.js"
     script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"
     script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"
     script src="/dist/main.bundle.js"

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -15,7 +15,7 @@ html
           == render(partial: "layouts/_nav.slang")
     .container
       .row
-	      .col-sm
+        .col-sm
           - flash.each do |key, value|
             div class="alert alert-#{key}"
               p = flash[key]

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -15,9 +15,10 @@ html
           == render(partial: "layouts/_nav.slang")
     div.container
       div.row
-        - flash.each do |key, value|
-          div class="alert alert-#{key}"
-            p = flash[key]
+	div.col-sm
+          - flash.each do |key, value|
+            div class="alert alert-#{key}"
+              p = flash[key]
       div.row
         div.col-sm-12.main
           == content

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -9,18 +9,18 @@ html
     link rel="stylesheet" href="/dist/main.bundle.css"
 
   body
-    div.masthead
-      div.container
+    .masthead
+      .container
         nav.nav
           == render(partial: "layouts/_nav.slang")
-    div.container
+    .container
       .row
-	      div.col-sm
+	      .col-sm
           - flash.each do |key, value|
             div class="alert alert-#{key}"
               p = flash[key]
       .row
-        div.col-sm-12.main
+        .col-sm-12.main
           == content
 
     script src="https://code.jquery.com/jquery-3.3.1.min.js"

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -14,12 +14,12 @@ html
         nav.nav
           == render(partial: "layouts/_nav.slang")
     div.container
-      div.row
+      .row
 	      div.col-sm
           - flash.each do |key, value|
             div class="alert alert-#{key}"
               p = flash[key]
-      div.row
+      .row
         div.col-sm-12.main
           == content
 

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -5,7 +5,7 @@ html
     meta charset="utf-8"
     meta http-equiv="X-UA-Compatible" content="IE=edge"
     meta name="viewport" content="width=device-width, initial-scale=1"
-    link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+    link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"
     link rel="stylesheet" href="/dist/main.bundle.css"
 
   body
@@ -22,6 +22,7 @@ html
         div.col-sm-12.main
           == content
 
-    script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"
-    script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+    script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"
+    script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"
     script src="/dist/main.bundle.js"

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -15,7 +15,7 @@ html
           == render(partial: "layouts/_nav.slang")
     div.container
       div.row
-	div.col-sm
+	      div.col-sm
           - flash.each do |key, value|
             div class="alert alert-#{key}"
               p = flash[key]

--- a/src/amber/cli/templates/auth/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/layouts/+_nav.ecr.ecr
@@ -1,10 +1,10 @@
 <%="<"%>%- if (current_<%= @name %> = context.current_<%= @name %>) %>
-  <a class="nav-item" href="/signout">| Sign Out</a>
+  <a class="nav-item nav-item-auth nav-item-auth-signout" href="/signout">| Sign Out</a>
   <%="<"%>%- active = context.request.path == "/profile" ? "active" : "" %>
-  <a class="nav-item <%="<"%>%= active %>" href="/profile"><%="<"%>%= current_<%= @name %>.email %></a>
+  <a class="nav-item nav-item-auth nav-item-auth-profile <%="<"%>%= active %>" href="/profile"><%="<"%>%= current_<%= @name %>.email %></a>
 <%="<"%>%- else %>
   <%="<"%>%- active = context.request.path == "/signup" ? "active" : "" %>
-  <a class="nav-item <%="<"%>%= active %>" href="/signup">| Sign Up</a>
+  <a class="nav-item nav-item-auth nav-item-auth-signup <%="<"%>%= active %>" href="/signup">| Sign Up</a>
   <%="<"%>%- active = context.request.path == "/signin" ? "active" : "" %>
-  <a class="nav-item <%="<"%>%= active %>" href="/signin">| Sign In</a>
+  <a class="nav-item nav-item-auth nav-item-auth-signin <%="<"%>%= active %>" href="/signin">| Sign In</a>
 <%="<"%>%- end %>

--- a/src/amber/cli/templates/auth/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/layouts/+_nav.ecr.ecr
@@ -1,10 +1,10 @@
 <%="<"%>%- if (current_<%= @name %> = context.current_<%= @name %>) %>
-  <a class="nav-item pull-right" href="/signout">| Sign Out</a>
+  <a class="nav-item ml-auto" href="/signout">| Sign Out</a>
   <%="<"%>%- active = context.request.path == "/profile" ? "active" : "" %>
-  <a class="nav-item <%="<"%>%= active %> pull-right" href="/profile"><%="<"%>%= current_<%= @name %>.email %></a>
+  <a class="nav-item <%="<"%>%= active %>" href="/profile"><%="<"%>%= current_<%= @name %>.email %></a>
 <%="<"%>%- else %>
   <%="<"%>%- active = context.request.path == "/signup" ? "active" : "" %>
-  <a class="nav-item <%="<"%>%= active %> pull-right" href="/signup">| Sign Up</a>
+  <a class="nav-item  ml-auto <%="<"%>%= active %>" href="/signup">| Sign Up</a>
   <%="<"%>%- active = context.request.path == "/signin" ? "active" : "" %>
-  <a class="nav-item <%="<"%>%= active %> pull-right" href="/signin">| Sign In</a>
+  <a class="nav-item <%="<"%>%= active %>" href="/signin">| Sign In</a>
 <%="<"%>%- end %>

--- a/src/amber/cli/templates/auth/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/layouts/+_nav.ecr.ecr
@@ -1,10 +1,10 @@
 <%="<"%>%- if (current_<%= @name %> = context.current_<%= @name %>) %>
-  <a class="nav-item ml-auto" href="/signout">| Sign Out</a>
+  <a class="nav-item" href="/signout">| Sign Out</a>
   <%="<"%>%- active = context.request.path == "/profile" ? "active" : "" %>
   <a class="nav-item <%="<"%>%= active %>" href="/profile"><%="<"%>%= current_<%= @name %>.email %></a>
 <%="<"%>%- else %>
   <%="<"%>%- active = context.request.path == "/signup" ? "active" : "" %>
-  <a class="nav-item  ml-auto <%="<"%>%= active %>" href="/signup">| Sign Up</a>
+  <a class="nav-item <%="<"%>%= active %>" href="/signup">| Sign Up</a>
   <%="<"%>%- active = context.request.path == "/signin" ? "active" : "" %>
   <a class="nav-item <%="<"%>%= active %>" href="/signin">| Sign In</a>
 <%="<"%>%- end %>

--- a/src/amber/cli/templates/auth/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/layouts/+_nav.slang.ecr
@@ -1,13 +1,13 @@
 - if (current_<%= @name %> = context.current_<%= @name %>)
-  a.nav-item href="/signout"
+  a.nav-item.nav-item-auth.nav-item-auth-signout href="/signout"
     | Sign Out
   - active = context.request.path == "/profile" ? "active" : ""
-  a class="nav-item #{active}" href="/profile"
+  a class="nav-item nav-item-auth nav-item-auth-profile #{active}" href="/profile"
     == current_<%= @name %>.email
 - else
   - active = context.request.path == "/signup" ? "active" : ""
-  a class="nav-item #{active}" href="/signup"
+  a class="nav-item nav-item-auth nav-item-auth-signup #{active}" href="/signup"
     | Sign Up
   - active = context.request.path == "/signin" ? "active" : ""
-  a class="nav-item #{active}" href="/signin"
+  a class="nav-item nav-item-auth nav-item-auth-signin #{active}" href="/signin"
     | Sign In

--- a/src/amber/cli/templates/auth/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/layouts/+_nav.slang.ecr
@@ -1,12 +1,12 @@
 - if (current_<%= @name %> = context.current_<%= @name %>)
-  a.nav-item.ml-auto href="/signout"
+  a.nav-item href="/signout"
     | Sign Out
   - active = context.request.path == "/profile" ? "active" : ""
   a class="nav-item #{active}" href="/profile"
     == current_<%= @name %>.email
 - else
   - active = context.request.path == "/signup" ? "active" : ""
-  a class="nav-item ml-auto #{active}" href="/signup"
+  a class="nav-item #{active}" href="/signup"
     | Sign Up
   - active = context.request.path == "/signin" ? "active" : ""
   a class="nav-item #{active}" href="/signin"

--- a/src/amber/cli/templates/auth/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/layouts/+_nav.slang.ecr
@@ -1,13 +1,13 @@
 - if (current_<%= @name %> = context.current_<%= @name %>)
-  a.nav-item.pull-right href="/signout"
+  a.nav-item.ml-auto href="/signout"
     | Sign Out
   - active = context.request.path == "/profile" ? "active" : ""
-  a class="nav-item #{active} pull-right" href="/profile"
+  a class="nav-item #{active}" href="/profile"
     == current_<%= @name %>.email
 - else
   - active = context.request.path == "/signup" ? "active" : ""
-  a class="nav-item #{active} pull-right" href="/signup"
+  a class="nav-item ml-auto #{active}" href="/signup"
     | Sign Up
   - active = context.request.path == "/signin" ? "active" : ""
-  a class="nav-item #{active} pull-right" href="/signin"
+  a class="nav-item #{active}" href="/signin"
     | Sign In

--- a/src/amber/cli/templates/auth/src/views/registration/new.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/registration/new.ecr.ecr
@@ -16,7 +16,7 @@
   <div class="form-group">
     <input class="form-control" type="password" name="password" placeholder="Password"/>
   </div>
-  <button class="btn btn-primary btn-xs" type="submit">Register</button>
+  <button class="btn btn-primary btn-sm" type="submit">Register</button>
 </form>
 <hr/>
 <%="<"%>%= link_to("Already have an account?", "/signin") -%>

--- a/src/amber/cli/templates/auth/src/views/registration/new.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/registration/new.slang.ecr
@@ -11,7 +11,7 @@ form action="/registration" method="post"
     input.form-control type="email" name="email" placeholder="Email"
   .form-group
     input.form-control type="password" name="password" placeholder="Password"
-  button.btn.btn-primary.btn-xs type="submit"
+  button.btn.btn-primary.btn-sm type="submit"
     | Register
 <hr/>
 == link_to("Already have an account?", "/signin")

--- a/src/amber/cli/templates/auth/src/views/session/new.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/session/new.ecr.ecr
@@ -16,7 +16,7 @@
   <div class="form-group">
     <input class="form-control" type="password" name="password" placeholder="Password"/>
   </div>
-  <button class="btn btn-primary btn-xs" type="submit">Sign In</button>
+  <button class="btn btn-primary btn-sm" type="submit">Sign In</button>
 </form>
 <hr/>
 <%="<"%>%= link_to("Don't have an account yet?", "/signup") -%>

--- a/src/amber/cli/templates/auth/src/views/session/new.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/session/new.slang.ecr
@@ -11,6 +11,6 @@ form action="/session" method="post"
     input.form-control type="email" name="email" placeholder="Email"
   div.form-group
     input.form-control type="password" name="password" placeholder="Password"
-  button.btn.btn-primary.btn-xs type="submit" Sign In
+  button.btn.btn-primary.btn-sm type="submit" Sign In
 <hr/>
 == link_to("Don't have an account yet?", "/signup")

--- a/src/amber/cli/templates/auth/src/views/session/new.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/session/new.slang.ecr
@@ -7,9 +7,9 @@ h1 Sign In
 
 form action="/session" method="post"
   == csrf_tag
-  div.form-group
+  .form-group
     input.form-control type="email" name="email" placeholder="Email"
-  div.form-group
+  .form-group
     input.form-control type="password" name="password" placeholder="Password"
   button.btn.btn-primary.btn-sm type="submit" Sign In
 <hr/>

--- a/src/amber/cli/templates/auth/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/{{name}}/edit.ecr.ecr
@@ -14,5 +14,5 @@
     <input class="form-control" type="email" name="email" placeholder="Email" value="<%="<"%>%= <%= @name %>.email %>" />
   </div>
   <%="<"%>%= submit("Update", class: "btn btn-primary btn-sm") %>
-  <%="<"%>%= link_to("profile", "/profile", class: "btn btn-default btn-sm") %>
+  <%="<"%>%= link_to("profile", "/profile", class: "btn btn-light btn-sm") %>
 </form>

--- a/src/amber/cli/templates/auth/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/{{name}}/edit.ecr.ecr
@@ -13,6 +13,6 @@
   <div class="form-group">
     <input class="form-control" type="email" name="email" placeholder="Email" value="<%="<"%>%= <%= @name %>.email %>" />
   </div>
-  <%="<"%>%= submit("Update", class: "btn btn-primary btn-xs") %>
-  <%="<"%>%= link_to("profile", "/profile", class: "btn btn-default btn-xs") %>
+  <%="<"%>%= submit("Update", class: "btn btn-primary btn-sm") %>
+  <%="<"%>%= link_to("profile", "/profile", class: "btn btn-default btn-sm") %>
 </form>

--- a/src/amber/cli/templates/auth/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/{{name}}/edit.slang.ecr
@@ -9,5 +9,5 @@ h1 Edit Profile
   == csrf_tag
   .form-group
     input.form-control type="email" name="email" placeholder="Email" value="#{<%= @name %>.email}"
-  == submit("Update", class: "btn btn-primary btn-xs")
-  == link_to("profile", "/profile", class: "btn btn-default btn-xs")
+  == submit("Update", class: "btn btn-primary btn-sm")
+  == link_to("profile", "/profile", class: "btn btn-default btn-sm")

--- a/src/amber/cli/templates/auth/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/{{name}}/edit.slang.ecr
@@ -10,4 +10,4 @@ h1 Edit Profile
   .form-group
     input.form-control type="email" name="email" placeholder="Email" value="#{<%= @name %>.email}"
   == submit("Update", class: "btn btn-primary btn-sm")
-  == link_to("profile", "/profile", class: "btn btn-default btn-sm")
+  == link_to("profile", "/profile", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/auth/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/{{name}}/show.ecr.ecr
@@ -1,5 +1,5 @@
 <h1>Profile</h1>
 <p>
   <%="<"%>%= <%= @name %>.email %>
-  <%="<"%>%= link_to("edit", "/profile/edit", class: "btn btn-success btn-xs") %>
+  <%="<"%>%= link_to("edit", "/profile/edit", class: "btn btn-success btn-sm") %>
 </p>

--- a/src/amber/cli/templates/auth/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/auth/src/views/{{name}}/show.slang.ecr
@@ -1,4 +1,4 @@
 h1 Profile
 p
   == <%= @name %>.email
-  == link_to("edit", "/profile/edit", class: "btn btn-success btn-xs")
+  == link_to("edit", "/profile/edit", class: "btn btn-success btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -21,7 +21,10 @@
    when "text" -%>
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
-    <%="<"%>%= label(<%=":#{field.name}"%>) { check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>) } -%>
+  <%="<"%>%= label(<%=":#{field.name}"%>, class: "form-check-label") do
+    check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>,
+              class: "form-check-input")
+  end -%>
 <% when "reference" -%>
     <%="<"%>%= label(<%=":#{field.name}"%>) -%>
     <%="<"%>%= select_field(name: "<%= field.name %>_id", collection: <%= field.name.capitalize %>.all.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control") -%>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -33,5 +33,5 @@
   </div>
 <% end -%>
   <%="<"%>%= submit("Submit", class: "btn btn-primary btn-sm") -%>
-  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-sm") -%>
+  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-light btn-sm") -%>
 </form>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -32,6 +32,6 @@
 <% end -%>
   </div>
 <% end -%>
-  <%="<"%>%= submit("Submit", class: "btn btn-primary btn-xs") -%>
-  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-xs") -%>
+  <%="<"%>%= submit("Submit", class: "btn btn-primary btn-sm") -%>
+  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-sm") -%>
 </form>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -21,9 +21,7 @@
    when "text" -%>
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
-    <div class="form-check">
-      <%="<"%>%= label(<%=":#{field.name}"%>, class: "form-check-label") { check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>, class: "form-check-input") } -%>
-    </div>
+    <%="<"%>%= label(<%=":#{field.name}"%>) { check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>) } -%>
 <% when "reference" -%>
     <%="<"%>%= label(<%=":#{field.name}"%>) -%>
     <%="<"%>%= select_field(name: "<%= field.name %>_id", collection: <%= field.name.capitalize %>.all.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control") -%>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -22,7 +22,7 @@
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
     <div class="form-check">
-      <%="<"%>%= label(<%=":#{field.name}"%>, class: "form-check-label") { check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\"", class: "form-check-input"%>) } -%>
+      <%="<"%>%= label(<%=":#{field.name}"%>, class: "form-check-label") { check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>, class: "form-check-input") } -%>
     </div>
 <% when "reference" -%>
     <%="<"%>%= label(<%=":#{field.name}"%>) -%>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -21,8 +21,8 @@
    when "text" -%>
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
-    <div class="checkbox">
-      <%="<"%>%= label(<%=":#{field.name}"%>) { check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>) } -%>
+    <div class="form-check">
+      <%="<"%>%= label(<%=":#{field.name}"%>, class: "form-check-label") { check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\"", class: "form-check-input"%>) } -%>
     </div>
 <% when "reference" -%>
     <%="<"%>%= label(<%=":#{field.name}"%>) -%>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -11,9 +11,9 @@
      when "text" -%>
     == text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10")
   <%- when "boolean" -%>
-    div.checkbox
-      == label(<%=":#{field.name}"%>) do
-        == check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>)
+    div.form-check
+      == label(<%=":#{field.name}"%>, class: "form-check-label") do
+        == check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>, class: "form-check-input")
   <%- when "reference" -%>
     == label(<%=":#{field.name}"%>)
     == select_field(name: "<%= field.name %>_id", collection: <%= field.name.capitalize %>.all.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -21,5 +21,5 @@
     == text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control")
   <%- end -%>
 <%- end -%>
-  == submit("Submit", class: "btn btn-primary btn-xs")
-  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-xs")
+  == submit("Submit", class: "btn btn-primary btn-sm")
+  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -22,4 +22,4 @@
   <%- end -%>
 <%- end -%>
   == submit("Submit", class: "btn btn-primary btn-sm")
-  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-sm")
+  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -11,9 +11,8 @@
      when "text" -%>
     == text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10")
   <%- when "boolean" -%>
-    div.form-check
-      == label(<%=":#{field.name}"%>, class: "form-check-label") do
-        == check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>, class: "form-check-input")
+      == label(<%=":#{field.name}"%>) do
+        == check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>)
   <%- when "reference" -%>
     == label(<%=":#{field.name}"%>)
     == select_field(name: "<%= field.name %>_id", collection: <%= field.name.capitalize %>.all.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -6,7 +6,7 @@
 == form(action: "/<%= Inflector.pluralize(@name) -%>/#{<%= @name -%>.id.to_s}", method: <%= @name %>.id ? :patch : :post) do
   == csrf_tag
 <%- @fields.reject{|f| f.hidden }.each do |field| -%>
-  div.form-group
+  .form-group
   <%- case field.type
      when "text" -%>
     == text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -3,7 +3,7 @@
     <h2><%= Inflector.pluralize(display_name) %></h2>
   </div>
   <div class="col-sm-1">
-    <a class="btn btn-success btn-xs" href="/<%= Inflector.pluralize(@name) %>/new">New</a>
+    <a class="btn btn-success btn-sm" href="/<%= Inflector.pluralize(@name) %>/new">New</a>
   </div>
 </div>
 
@@ -24,9 +24,9 @@
 <% end -%>
         <td>
           <span>
-            <%="<"%>%= link_to("read", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-primary btn-xs") -%>
-            <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs") -%>
-            <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-xs") -%>
+            <%="<"%>%= link_to("read", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm") -%>
+            <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
+            <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
           </span>
         </td>
       </tr>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -2,7 +2,7 @@ div.row
   div.col-sm-11
     h2 <%= Inflector.pluralize(display_name) %>
   div.col-sm-1
-    a.btn.btn-success.btn-xs href="/<%= Inflector.pluralize(@name) %>/new" New
+    a.btn.btn-success.btn-sm href="/<%= Inflector.pluralize(@name) %>/new" New
 div.table-responsive
   table.table.table-striped
     thead
@@ -19,6 +19,6 @@ div.table-responsive
           <%- end -%>
           td
             span
-              == link_to("read", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-primary btn-xs")
-              == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs")
-              == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{ <%= @name %>.id }?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-xs")
+              == link_to("read", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm")
+              == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
+              == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{ <%= @name %>.id }?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -1,4 +1,4 @@
-div.row
+.row
   div.col-sm-11
     h2 <%= Inflector.pluralize(display_name) %>
   div.col-sm-1

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -1,9 +1,9 @@
 .row
-  div.col-sm-11
+  .col-sm-11
     h2 <%= Inflector.pluralize(display_name) %>
-  div.col-sm-1
+  .col-sm-1
     a.btn.btn-success.btn-sm href="/<%= Inflector.pluralize(@name) %>/new" New
-div.table-responsive
+.table-responsive
   table.table.table-striped
     thead
       tr

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
@@ -4,7 +4,7 @@
 <p><%="<"%>%= <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %> %></p>
 <% end -%>
 <p>
-  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>s", class: "btn btn-default btn-xs") -%>
-  <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs") -%>
-  <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-xs") -%>
+  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>s", class: "btn btn-default btn-sm") -%>
+  <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
+  <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
 </p>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
@@ -4,7 +4,7 @@
 <p><%="<"%>%= <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %> %></p>
 <% end -%>
 <p>
-  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>s", class: "btn btn-default btn-sm") -%>
+  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>s", class: "btn btn-light btn-sm") -%>
   <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
   <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
 </p>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
@@ -3,6 +3,6 @@ h1 Show <%= display_name %>
 p = <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %>
 <% end -%>
 p
-  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-xs")
-  == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs")
-  == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-xs")
+  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-sm")
+  == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
+  == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
@@ -3,6 +3,6 @@ h1 Show <%= display_name %>
 p = <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %>
 <% end -%>
 p
-  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-default btn-sm")
+  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-light btn-sm")
   == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
   == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")


### PR DESCRIPTION
### Description of the Change

![screen shot 2018-04-20 at 22 33 43](https://user-images.githubusercontent.com/19265077/39064110-e7996ae6-44ea-11e8-873d-efbc4c5ae364.png)

Added responsive navbar with toggle button for mobile screens.
Removed `.masthead` inset box-shadow to make the design look cleaner (can add it back if you want).
Fixed breakpoint values to correctly transition to mobile mode on screen resize.
Added border radius to `#logo` to look more streamlined (since the links also have a border-radius)

### Alternate Designs

I was considering making `#logo` a banner kind of area just below the navbar. Like this:
![image](https://user-images.githubusercontent.com/19265077/39061051-b4a9cdb0-44e0-11e8-89da-509cccb72b2f.png)
But i discarded that because I didn't want to make any major changes.

### Benefits

The generated boilerplate is now responsive, and the design is a tiny bit cleaner :sweat_smile: 

### Possible Drawbacks

* no box-shadow on `.masthead`.
* has horizontal scrollbar (working on it!)
![screen shot 2018-04-20 at 22 34 27](https://user-images.githubusercontent.com/19265077/39064152-0a4f4588-44eb-11e8-8069-55e016cdff46.png)



